### PR TITLE
Remove resource pool size

### DIFF
--- a/templates/datadog-firehose-nozzle-template.yml
+++ b/templates/datadog-firehose-nozzle-template.yml
@@ -28,7 +28,6 @@ resource_pools:
 - name: datadog-firehose-nozzle
   network: datadog-firehose-nozzle-net
   stemcell: (( meta.stemcell ))
-  size: (( merge ))
   cloud_properties: (( merge ))
 
 jobs:


### PR DESCRIPTION
Bosh computes the resource pool size by default and doesn't need to specified manually.

https://bosh.io/docs/deployment-manifest.html#resource-pools
