### PR TITLE
Templatize bosh UUID

### DIFF
--- a/bosh-lite/stub.yml
+++ b/bosh-lite/stub.yml
@@ -6,7 +6,7 @@ meta:
     version: latest
 
 name: datadog-firehose-nozzle
-director_uuid: PLACEHOLDER-DIRECTOR-UUID
+director_uuid: <%= `bosh status --uuid` %>
 
 compilation:
   workers: 1


### PR DESCRIPTION
This change templatizes bosh's UUID to the current running. Inspired by concourse `bosh-lite.yml` file at https://github.com/concourse/concourse/blob/master/manifests/bosh-lite.yml#L4

Signed-off-by: Matthew Boedicker mboedicker@pivotal.io
