### PR TITLE
Add support for metron error event envelope

### DIFF
--- a/jobs/datadog-firehose-nozzle/spec
+++ b/jobs/datadog-firehose-nozzle/spec
@@ -14,7 +14,7 @@ properties:
     description: "Traffic controller URL"
   datadog.api_url:
     description: "The REST API Endpoint for datadog"
-    default: "https://app.datadoghq.com/api/v1/series"
+    default: "https://app.datadoghq.com/api/v1"
   datadog.api_key:
     description: "The datadog API key to use while submitting requests"
   datadog.flush_duration_seconds:


### PR DESCRIPTION
Crop default datadog.api_url to be able to emit both series and events

Relies upon changes in https://github.com/masters-of-cats/datadog-firehose-nozzle/commit/2b046b06eb888a38adc175ebaba3e0c86735e908

Part of: #143312267

Signed-off-by: Claudia Beresford <cberesford@pivotal.io>